### PR TITLE
Create a quick deploy docker compose file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,7 @@ TEST_CKAN_DATASTORE_WRITE_URL=postgresql://ckan:ckan@db/datastore_test
 TEST_CKAN_DATASTORE_READ_URL=postgresql://datastore_ro:datastore@db/datastore_test
 
 # CKAN core
+## If use docker-compose.ghcr.yml only "*.*.*" versions available in: https://github.com/opendatagis/ckan-iepnb/pkgs/container/ckan-iepnb
 CKAN_VERSION=2.9.8
 CKAN_SITE_ID=default
 # CKAN_SITE_URL = http:/ or https:/ + APACHE_SERVER_NAME. Optionally the APACHE_HOST_PORT if different from 80 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Information about extensions installed in the `main` image. More info described 
 | Extension   | [ckanext-pages](https://github.com/ckan/ckanext-pages)                                  | 0.5.1       | Completed                    | ✔️      | ✔️      | Stable installation. This extension gives you an easy way to add simple pages to CKAN.                                                                                                                                                                                                                                                                                  |
 | Extension   | [ckanext-pdfview](https://github.com/ckan/ckanext-pdfview)                              | 0.0.8       | Completed                    | ✔️      | ✔️      | Stable installation. This extension provides a view plugin for PDF files using an html object tag.                                                                                                                                                                                                                                                                      |
 | Extension    | [ckanext-iepnb](https://github.com/OpenDataGIS/ckanext-iepnb)                                    | 0.1.2        | Completed | ✔️      | ✔️       | Stable installation for 0.1.2 version, the modification of the Solr schema.xml with the new fields for faceted and failed python dependencies needs to be reviewed.                                                                                                                                                                             |
-| Software    | [ckan-pycsw](https://github.com/mjanez/ckan-pycsw)                                    | main        | Completed | ✔️      | ✔️       | Stable installation. PyCSW Endpoint of Open Data Portal with docker compose config. Harvest the CKAN catalogue in a CSW endpoint based on existing spatial datasets in the open data portal.                                                                                                                                                                            |
+| Software    | [ckan-pycsw](https://github.com/mjanez/ckan-pycsw)                                    | latest        | Completed | ✔️      | ✔️       | Stable installation. PyCSW Endpoint of Open Data Portal with docker compose config. Harvest the CKAN catalogue in a CSW endpoint based on existing spatial datasets in the open data portal.                                                                                                                                                                            |
 
 
 ## Environment: docker
@@ -200,31 +200,24 @@ Use this if you are a maintainer and will not be making code changes to CKAN or 
 
 3. Build the images:
     ```bash
-    docker compose build
+    docker compose build 
     ```
+
     >**Note**<br>
-    > NGINX CKAN without ckan-pycsw and Apache:
-    >```bash
-    >docker compose -f docker-compose.nginx.yml build
-    >```
-  
+    > You can use a [deploy in 5 minutes](#quick-mode) if you just want to test the package. 
+
 4. Start the containers:
     ```bash
     docker compose up
     ```
-
-    >**Note**<br>
-    > NGINX CKAN without ckan-pycsw and Apache:
-    >```bash
-    >docker compose -f docker-compose.nginx.yml up
-    >```
 
 This will start up the containers in the current window. By default the containers will log direct to this window with each container
 using a different colour. You could also use the -d "detach mode" option ie: `docker compose up -d` if you wished to use the current 
 window for something else.
 
 >**Note**<br>
-> Or `docker compose up --build` to build & up the containers.
+> * Or `docker compose up --build` to build & up the containers.
+> * Or `docker compose -f docker-compose.nginx.yml up -d --build` to use the NGINX version.
 
 At the end of the container start sequence there should be 6 containers running (or 5 if use NGINX Docker Compose file)
 
@@ -237,7 +230,7 @@ After this step, CKAN should be running at {`APACHE_SERVER_NAME`}{`APACHE_CKAN_L
 |1b8d9789c29a|redis:7-alpine                           |docker-entrypoint.s…|6      minutes ago   |Up   4    minutes (healthy)|6379/tcp              |redis                |       |
 |7f162741254d|ckan/ckan-solr:2.9-solr8-spatial  |docker-entrypoint.s…|6      minutes ago   |Up   4    minutes (healthy)|8983/tcp              |solr                 |       |
 |2cdd25cea0de|ckan-docker-iepnb-db                    |docker-entrypoint.s…|6      minutes ago   |Up   4    minutes (healthy)|5432/tcp              |db                   |       |
-|9cdj25dae6gr|ckan-docker-iepnb-pycsw                    |docker-entrypoint.s…|6      minutes ago   |Up   4    minutes (healthy)|8000/tcp              |db                   |       |
+|9cdj25dae6gr|ckan-docker-iepnb-pycsw                    |docker-entrypoint.s…|6      minutes ago   |Up   4    minutes (healthy)|8000/tcp              |pycsw                   |       |
 
 
 #### Configure a docker compose service to start on boot
@@ -295,6 +288,17 @@ To have Docker Compose run automatically when you reboot a machine, you can foll
   # Check the status
   sudo systemctl status ckan-docker-compose
   ```
+
+### Quick mode
+If you just want to test the package and see the general functionality of the platform, you can use the `ckan-iepnb` image from the [Github container registry](https://github.com/opendatagis/ckan-iepnb/pkgs/container/ckan-iepnb):
+    
+  ```bash
+  cp .env.example .env
+  # Edit the envvars in the .env as you like and start the containers.
+  docker compose -f docker-compose.ghcr.yml up -d --build 
+  ```
+
+It will download the pre-built image and deploy all the containers. Remember to use your own domain by changing `localhost` in the `.env` file.
 
 ### Development mode
 Use this mode if you are making code changes to CKAN and either creating new extensions or making code changes to existing extensions. This mode also uses the `.env` file for config options.

--- a/ckan/Dockerfile.ghcr
+++ b/ckan/Dockerfile.ghcr
@@ -1,0 +1,37 @@
+FROM ghcr.io/opendatagis/ckan-iepnb:ckan-2.9.8
+
+# Set up environment variables
+ENV APP_DIR=/srv/app
+ENV TZ=UTC
+RUN echo ${TZ} > /etc/timezone
+
+# Make sure both files are not exactly the same
+RUN if ! [ /usr/share/zoneinfo/${TZ} -ef /etc/localtime ]; then \
+    cp /usr/share/zoneinfo/${TZ} /etc/localtime ;\
+    fi ;
+
+# Used to configure the container environment by setting environment variables, creating users, running initialization scripts, .etc
+COPY docker-entrypoint.d/* /docker-entrypoint.d/
+
+# Update who.ini with APACHE_CKAN_LOCATION
+COPY setup/who.ini ${APP_DIR}/
+
+# Apply any patches needed to CKAN core
+COPY patches ${APP_DIR}/patches
+
+#  Updated version of the Dockerfile RUN command that skips applying a patch if a reversed or previously applied patch is detected
+RUN for d in $APP_DIR/patches/*; do \
+    if [ -d $d ]; then \
+        for f in `ls $d/*.patch | sort -g`; do \
+            cd $SRC_DIR/`basename "$d"` && \
+            if patch -R --dry-run -p1 < "$f"; then \
+                echo "$0: Patch $f has already been applied or reversed, skipping..."; \
+            else \
+                echo "$0: Applying patch $f to $SRC_DIR/`basename $d`"; \
+                patch -p1 < "$f" ; \
+            fi \
+        done ; \
+    fi ; \
+done
+
+CMD $APP_DIR/start_ckan.sh

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -30,7 +30,7 @@ services:
     container_name: ${CKAN_CONTAINER_NAME}
     build:
       context: ckan/
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.ghcr
       args:
         - TZ=${TZ}
     env_file:


### PR DESCRIPTION
- Remove ckan-spatial from default docker compose file
- Create a docker-compose.ghcr.yml to use the ckan-spatial image from container registry
- Update the README to include this information
- Update .env.example to info about CKAN_VERSION ennvar