### PR TITLE
Update DCAT version to 1.8.0-alpha in Dockerfile for IEPNB compatibility

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -18,7 +18,7 @@ COPY req_fixes req_fixes
 ## Harvest - v1.5.6 (Worker with supervisor) ##
 ## Geoview - v0.2.0 ##
 ## Spatial - v2.1.1 ##
-## DCAT - v1.8.0 (Latest stable version of ckanext-dcat with minor fixes) ##
+## DCAT - v1.8.0-alpha (Latest old version for IEPNB) ##
 ## Scheming - release-3.0.0 ##
 ## Resource dictionary - v1.0.2 (mjanez/Fixed version) ##
 ## Pages - v0.5.2 ##
@@ -47,7 +47,7 @@ RUN echo ${TZ} > /etc/timezone && \
     pip3 install --no-cache-dir -e git+https://github.com/ckan/ckanext-spatial.git@v2.1.1#egg=ckanext-spatial && \
     pip3 install --no-cache-dir -r ${APP_DIR}/req_fixes/ckanext-spatial/requirements.txt && \
     echo "mjanez/ckanext-dcat (GeoDCAT-AP extended version)" && \
-    pip3 install --no-cache-dir -e git+https://github.com/mjanez/ckanext-dcat.git@v1.8.0#egg=ckanext-dcat && \
+    pip3 install --no-cache-dir -e git+https://github.com/mjanez/ckanext-dcat.git@v1.8.0-alpha#egg=ckanext-dcat && \
     pip3 install --no-cache-dir -r ${APP_DIR}/src/ckanext-dcat/requirements.txt && \
     echo "ckan/ckanext-scheming" && \
     pip3 install --no-cache-dir -e git+https://github.com/ckan/ckanext-scheming.git@release-3.0.0#egg=ckanext-scheming && \


### PR DESCRIPTION
This pull request includes changes to `ckan/Dockerfile` to update the version of `ckanext-dcat` to a stable version for IEPNB.