### PR TITLE
Update .env.example to modify ckanext-schemingdcat facet list and default package item icon, updates ckanext-iepnb to v2.3.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -201,10 +201,10 @@ CKAN___SCHEMING__GROUP_SCHEMAS="ckanext.schemingdcat:schemas/geodcatap_es/geodca
 CKAN___SCHEMING__ORGANIZATION_SCHEMAS="ckanext.schemingdcat:schemas/geodcatap_es/geodcatap_es_org.json"
 CKAN___SCHEMING__PRESETS="ckanext.schemingdcat:schemas/default_presets.json ckanext.fluent:presets.json ckanext.iepnb:schemas/presets.json"
 ## Facets: setup_scheming.sh
-CKANEXT__SCHEMINGDCAT__FACET_LIST="thematic_area dataset_scope tags groups  theme dcat_type groups spatial_uri owner_org res_format frequency tag_uri conforms_to"
+CKANEXT__SCHEMINGDCAT__FACET_LIST="thematic_area dataset_scope tags groups  dcat_type groups spatial_uri owner_org res_format frequency tag_uri conforms_to"
 CKANEXT__SCHEMINGDCAT__ORGANIZATION_CUSTOM_FACETS=True
 CKANEXT__SCHEMINGDCAT__GROUP_CUSTOM_FACETS=True
-CKANEXT__SCHEMINGDCAT__DEFAULT_PACKAGE_ITEM_ICON="theme"
+CKANEXT__SCHEMINGDCAT__DEFAULT_PACKAGE_ITEM_ICON="theme_es"
 CKANEXT__SCHEMINGDCAT__DEFAULT_PACKAGE_ITEM_SHOW_SPATIAL=True
 CKANEXT__SCHEMINGDCAT__SHOW_METADATA_TEMPLATES_TOOLBAR=True
 CKANEXT__SCHEMINGDCAT__METADATA_TEMPLATES_SEARCH_IDENTIFIER="iepnb-plantilla"

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -25,7 +25,7 @@ COPY req_fixes req_fixes
 ## PDFView - 0.0.8 ##
 ## Fluent - v1.0.1  (mjanez/Forked stable version) ##
 ## Scheming DCAT - v3.2.3 (mjanez/GeoDCAT-AP/NTI-RISP extended version) ##
-## IEPNB - v2.3.1 (OpenDataGIS/IEPNB) ##
+## IEPNB - v2.3.2 (OpenDataGIS/IEPNB) ##
 RUN echo ${TZ} > /etc/timezone && \
     if ! [ /usr/share/zoneinfo/${TZ} -ef /etc/localtime ]; then cp /usr/share/zoneinfo/${TZ} /etc/localtime; fi && \
     # Remove apk cache
@@ -63,7 +63,7 @@ RUN echo ${TZ} > /etc/timezone && \
     pip3 install --no-cache-dir -e git+https://github.com/mjanez/ckanext-schemingdcat.git@v3.2.3#egg=ckanext_schemingdcat && \
     pip3 install --no-cache-dir -r ${APP_DIR}/src/ckanext-schemingdcat/requirements.txt && \
     echo "OpenDataGIS/ckanext-iepnb" && \
-    pip3 install --no-cache-dir -e git+https://${ACCESS_TOKEN}@github.com/OpenDataGIS/ckanext-iepnb.git@v2.3.1#egg=ckanext-iepnb && \
+    pip3 install --no-cache-dir -e git+https://${ACCESS_TOKEN}@github.com/OpenDataGIS/ckanext-iepnb.git@v2.3.2#egg=ckanext-iepnb && \
     pip3 install --no-cache-dir -r ${APP_DIR}/src/ckanext-iepnb/requirements.txt && \
     echo "OpenDataGIS/ckanext-sparql_interface" && \
     pip3 install --no-cache-dir -e git+https://github.com/OpenDataGIS/ckanext-sparql_interface.git@2.0.3-iepnb#egg=ckanext-sparql_interface && \


### PR DESCRIPTION
This pull request includes changes to the configuration and Docker setup for the CKAN project. The most important changes involve updating the version of the IEPNB extension and modifying the configuration for scheming facets and package item icons.

### Configuration Changes:

* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL204-R207): Updated `CKANEXT__SCHEMINGDCAT__FACET_LIST` by removing the `theme` facet and changed `CKANEXT__SCHEMINGDCAT__DEFAULT_PACKAGE_ITEM_ICON` to `theme_es`.

### Docker Setup:

* [`ckan/Dockerfile`](diffhunk://#diff-2255ee862e56fe4f21e684dd00e9f290aebbc3fbb7ac11a56c21ade18cff6f3aL28-R28): Updated the version of the IEPNB extension from `v2.3.1` to `v2.3.2` in the comments and in the `pip3 install` command. [[1]](diffhunk://#diff-2255ee862e56fe4f21e684dd00e9f290aebbc3fbb7ac11a56c21ade18cff6f3aL28-R28) [[2]](diffhunk://#diff-2255ee862e56fe4f21e684dd00e9f290aebbc3fbb7ac11a56c21ade18cff6f3aL66-R66)