### PR TITLE
Update CKAN Dockerfile: upgrade Geoview to v0.2.2 and IEPNB to v2.4.0 for improved compatibility

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -16,7 +16,7 @@ COPY req_fixes req_fixes
 # CKAN configuration & extensions
 ## XLoader - 1.0.1-stable (mjanez/Forked fixed version) ##
 ## Harvest - v1.5.6 (mjanez Enhanced Privacy and Security for Remote Harvesting) ##
-## Geoview - v0.2.0 ##
+## Geoview - v0.2.2 ##
 ## Spatial - v2.1.1 ##
 ## DCAT - v1.8.0-alpha (Latest old version for IEPNB) ##
 ## Scheming - release-3.0.0 ##
@@ -24,8 +24,8 @@ COPY req_fixes req_fixes
 ## Pages - v0.5.2 ##
 ## PDFView - 0.0.8 ##
 ## Fluent - v1.0.1  (mjanez/Forked stable version) ##
-## Scheming DCAT - v3.2.3 (mjanez/GeoDCAT-AP/NTI-RISP extended version) ##
-## IEPNB - v2.3.2 (OpenDataGIS/IEPNB) ##
+## Scheming DCAT - v3.2.3 (mjanez/GeoDCAT-AP/NTI-RISP extended version - IEPNB 2.9.12 compatible) ##
+## IEPNB - v2.4.0 (OpenDataGIS/IEPNB - MITECO Schema alignement) ##
 RUN echo ${TZ} > /etc/timezone && \
     if ! [ /usr/share/zoneinfo/${TZ} -ef /etc/localtime ]; then cp /usr/share/zoneinfo/${TZ} /etc/localtime; fi && \
     # Remove apk cache
@@ -42,7 +42,7 @@ RUN echo ${TZ} > /etc/timezone && \
     pip3 install --no-cache-dir -e git+https://github.com/mjanez/ckanext-harvest.git@v1.5.6#egg=ckanext-harvest && \
     pip3 install --no-cache-dir -r ${APP_DIR}/src/ckanext-harvest/requirements.txt && \
     echo "ckan/ckanext-geoview" && \
-    pip3 install --no-cache-dir -e git+https://github.com/ckan/ckanext-geoview.git@v0.2.0#egg=ckanext-geoview && \
+    pip3 install --no-cache-dir -e git+https://github.com/ckan/ckanext-geoview.git@v0.2.2#egg=ckanext-geoview && \
     echo "ckan/ckanext-spatial" && \
     pip3 install --no-cache-dir -e git+https://github.com/ckan/ckanext-spatial.git@v2.1.1#egg=ckanext-spatial && \
     pip3 install --no-cache-dir -r ${APP_DIR}/req_fixes/ckanext-spatial/requirements.txt && \
@@ -63,7 +63,7 @@ RUN echo ${TZ} > /etc/timezone && \
     pip3 install --no-cache-dir -e git+https://github.com/mjanez/ckanext-schemingdcat.git@v3.2.3#egg=ckanext_schemingdcat && \
     pip3 install --no-cache-dir -r ${APP_DIR}/src/ckanext-schemingdcat/requirements.txt && \
     echo "OpenDataGIS/ckanext-iepnb" && \
-    pip3 install --no-cache-dir -e git+https://${ACCESS_TOKEN}@github.com/OpenDataGIS/ckanext-iepnb.git@v2.3.2#egg=ckanext-iepnb && \
+    pip3 install --no-cache-dir -e git+https://${ACCESS_TOKEN}@github.com/OpenDataGIS/ckanext-iepnb.git@v2.4.0#egg=ckanext-iepnb && \
     pip3 install --no-cache-dir -r ${APP_DIR}/src/ckanext-iepnb/requirements.txt && \
     echo "OpenDataGIS/ckanext-sparql_interface" && \
     pip3 install --no-cache-dir -e git+https://github.com/OpenDataGIS/ckanext-sparql_interface.git@2.0.3-iepnb#egg=ckanext-sparql_interface && \


### PR DESCRIPTION

This pull request includes updates to several CKAN extensions and dependencies in the `ckan/Dockerfile`. 

CKAN extension updates:

* Updated `ckanext-geoview` extension from version `0.2.0` to `0.2.2` in the CKAN configuration and installation command.
* Updated `ckanext-iepnb` extension from version `2.3.2` to `2.4.0`, which includes MITECO Schema alignment.
* Improve comments `ckanext-schemingdcat` to explain compat with the stable IEPNB version `2.9.12`.